### PR TITLE
Work with new changes in Coverage.jl

### DIFF
--- a/run_coverage_codecov.sh
+++ b/run_coverage_codecov.sh
@@ -30,4 +30,4 @@ cd ..
 ./julia -e 'using Coverage, HDF5, JLD; results=Codecov.process_folder("base"); save("coverage_noinline.jld", "results", results)'
 
 # Merge results and submit
-./julia -e 'using Coverage, CoverageBase, HDF5, JLD; r1 = load("coverage_noinline.jld", "results"); r2 = load("coverage_inline.jld", "results"); r = CoverageBase.merge_coverage_codecov(r1, r2); Codecov.submit_token(r)'
+./julia -e 'using Coverage, CoverageBase, HDF5, JLD; r1 = load("coverage_noinline.jld", "results"); r2 = load("coverage_inline.jld", "results"); r = CoverageBase.merge_coverage(r1, r2); Codecov.submit_token(r)'

--- a/src/CoverageBase.jl
+++ b/src/CoverageBase.jl
@@ -1,5 +1,5 @@
 module CoverageBase
-
+using Coverage
 export testnames, runtests, merge_coverage
 
 const need_inlining = ["reflection", "meta"]
@@ -59,12 +59,13 @@ function merge_coverage(r1a, r2a)
     r1 = todict(r1a)
     r2 = todict(r2a)
     files = union(collect(keys(r1)), collect(keys(r2)))
-    r = []
+    r = FileCoverage[]
     for f in files
         src = haskey(r1, f) ? r1[f][1] : r2[f][1]
         c1 = haskey(r1, f) ? r1[f][2] : []
         c2 = haskey(r2, f) ? r2[f][2] : []
-        push!(r, Dict("name" => f, "source" => src, "coverage" => merge_coverage_counts(c1,c2)))
+        ff = FileCoverage(f,src,Coverage.merge_coverage_counts(c1,c2))
+        push!(r,ff)
     end
     r
 end
@@ -72,7 +73,7 @@ end
 function todict(results)
     d = Dict{Any,Any}()
     for r in results
-        d[r["name"]] = (r["source"], r["coverage"])
+        d[r.filename] = (r.source, r.coverage)
     end
     d
 end

--- a/src/CoverageBase.jl
+++ b/src/CoverageBase.jl
@@ -62,8 +62,8 @@ function merge_coverage(r1a, r2a)
     r = FileCoverage[]
     for f in files
         src = haskey(r1, f) ? r1[f][1] : r2[f][1]
-        c1 = haskey(r1, f) ? r1[f][2] : []
-        c2 = haskey(r2, f) ? r2[f][2] : []
+        c1 = haskey(r1, f) ? r1[f][2] : Union(Void,Int)[nothing]
+        c2 = haskey(r2, f) ? r2[f][2] : Union(Void,Int)[nothing]
         ff = FileCoverage(f,src,Coverage.merge_coverage_counts(c1,c2))
         push!(r,ff)
     end
@@ -74,39 +74,6 @@ function todict(results)
     d = Dict{Any,Any}()
     for r in results
         d[r.filename] = (r.source, r.coverage)
-    end
-    d
-end
-
-function merge_coverage_counts_codecov(a1, a2)
-    n = max(length(a1),length(a2))
-    a = Array(Union(Void,Int), n)
-    for i = 1:n
-        a1v = isdefined(a1, i) ? a1[i] : nothing
-        a2v = isdefined(a2, i) ? a2[i] : nothing
-        a[i] = a1v == nothing ? a2v :
-               a2v == nothing ? a1v : max(a1v, a2v)
-    end
-    a
-end
-
-function merge_coverage_codecov(r1a, r2a)
-    r1 = todict_codecov(r1a)
-    r2 = todict_codecov(r2a)
-    files = union(collect(keys(r1)), collect(keys(r2)))
-    r = []
-    for f in files
-        c1 = haskey(r1, f) ? r1[f] : []
-        c2 = haskey(r2, f) ? r2[f] : []
-        push!(r, (string(f),merge_coverage_counts_codecov(c1,c2)))
-    end
-    r
-end
-
-function todict_codecov(results)
-    d = Dict{Any,Any}()
-    for r in results
-        d[r[1]] = r[2]
     end
     d
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using CoverageBase
+using Coverage
 using Base.Test
 
 @test !isempty(CoverageBase.julia_top())
@@ -6,31 +7,18 @@ using Base.Test
 @test_throws ErrorException runtests(["junk"])
 runtests([joinpath(CoverageBase.julia_top(), "test", "goto")])
 
-r1 = [Dict("name" => "a", "source" => "blahblah", "coverage" => [1,nothing,1,nothing]),
-      Dict("name" => "b", "source" => "blahblah", "coverage" => [nothing,5])]
-r2 = [Dict("name" => "a", "source" => "blahblah", "coverage" => [3,nothing,0,2])]
+r1 = FileCoverage[FileCoverage("a","blahblah",[1,nothing,1,nothing]),
+                  FileCoverage("b","blahblah",[nothing,5])]
+r2 = FileCoverage[FileCoverage("a","blahblah",[3,nothing,0,2])]
 
 r = merge_coverage(r1, r2)
 @test length(r) == 2
 for ri in r
-    if ri["name"] == "a"
-        @test ri["coverage"] == [3,nothing,1,2]
-    elseif ri["name"] == "b"
-        @test ri["coverage"] == [nothing,5]
+    if ri.filename == "a"
+        @test ri.coverage == [3,nothing,1,2]
+    elseif ri.filename == "b"
+        @test ri.coverage == [nothing,5]
     else
         error("test not recognized")
-    end
-end
-
-cr1 = [("a",[1,nothing,1,nothing]),
-      ("b",[nothing,5])]
-cr2 = [("a",[3,nothing,0,2])]
-cr = CoverageBase.merge_coverage_codecov(cr1, cr2)
-@test length(cr) == 2
-for ri in r
-    if haskey(ri,"a")
-        @test ri["a"] == [3,nothing,1,2]
-    elseif haskey(ri,"b")
-        @test ri["b"] == [nothing,5]
     end
 end


### PR DESCRIPTION
Updated the merging of coverage counts to work with the refactoring in Coverage.jl. Tested; works with codecov at least.
