### PR TITLE
Remove merge_coverage and friends

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.4-
+julia 0.4
 Coverage
-JLD

--- a/run_coverage.sh
+++ b/run_coverage.sh
@@ -12,22 +12,13 @@ make
 # Clean old *.cov files
 rm $(find base -name "*.jl.*cov")
 
+cd test
 # Run coverage with inlining on, to test the few that don't run with it off
-cd test
 ../julia --precompiled=no --code-coverage=all -e 'import CoverageBase; using Base.Test; CoverageBase.runtests(CoverageBase.testnames())'
-cd ..
-
-# Analyze results
-./julia -e 'using Coverage, HDF5, JLD; results=Coveralls.process_folder("base"); save("coverage_inline.jld", "results", results)'
-rm $(find base -name "*.jl.*cov")
-
-# Run coverage with inline=no
-cd test
+# Run coverage without inlining, to test the rest of base
 ../julia --precompiled=no --inline=no --code-coverage=all -e 'import CoverageBase; using Base.Test; CoverageBase.runtests(CoverageBase.testnames())'
 cd ..
 
-# Analyze results
-./julia -e 'using Coverage, HDF5, JLD; results=Coveralls.process_folder("base"); save("coverage_noinline.jld", "results", results)'
-
-# Merge results and submit
-./julia -e 'using Coverage, CoverageBase, HDF5, JLD; r1 = load("coverage_noinline.jld", "results"); r2 = load("coverage_inline.jld", "results"); r = CoverageBase.merge_coverage(r1, r2); Coveralls.submit_token(r)'
+# Analyze and submit results
+./julia -e 'using Coverage, HDF5, JLD; results=Coveralls.process_folder("base"); Coveralls.submit_token(results)'
+rm $(find base -name "*.jl.*cov")

--- a/run_coverage.sh
+++ b/run_coverage.sh
@@ -20,5 +20,5 @@ cd test
 cd ..
 
 # Analyze and submit results
-./julia -e 'using Coverage, HDF5, JLD; results=Coveralls.process_folder("base"); Coveralls.submit_token(results)'
+./julia -e 'using Coverage; results=Coveralls.process_folder("base"); Coveralls.submit_token(results)'
 rm $(find base -name "*.jl.*cov")

--- a/run_coverage_codecov.sh
+++ b/run_coverage_codecov.sh
@@ -20,4 +20,4 @@ cd test
 cd ..
 
 # Analyze and submit results
-./julia -e 'using Coverage, HDF5, JLD; results=Codecov.process_folder("base"); Codecov.submit_token(results)'
+./julia -e 'using Coverage; results=Codecov.process_folder("base"); Codecov.submit_token(results)'

--- a/run_coverage_codecov.sh
+++ b/run_coverage_codecov.sh
@@ -12,22 +12,12 @@ make
 # Clean old *.cov files
 rm $(find base -name "*.jl.*cov")
 
+cd test
 # Run coverage with inlining on, to test the few that don't run with it off
-cd test
 ../julia --precompiled=no --code-coverage=all -e 'import CoverageBase; using Base.Test; CoverageBase.runtests(CoverageBase.testnames())'
-cd ..
-
-# Analyze results
-./julia -e 'using Coverage, HDF5, JLD; results=Codecov.process_folder("base"); save("coverage_inline.jld", "results", results)'
-rm $(find base -name "*.jl.*cov")
-
-# Run coverage with inline=no
-cd test
+# Run coverage without inlining, to test the rest of base
 ../julia --precompiled=no --inline=no --code-coverage=all -e 'import CoverageBase; using Base.Test; CoverageBase.runtests(CoverageBase.testnames())'
 cd ..
 
-# Analyze results
-./julia -e 'using Coverage, HDF5, JLD; results=Codecov.process_folder("base"); save("coverage_noinline.jld", "results", results)'
-
-# Merge results and submit
-./julia -e 'using Coverage, CoverageBase, HDF5, JLD; r1 = load("coverage_noinline.jld", "results"); r2 = load("coverage_inline.jld", "results"); r = CoverageBase.merge_coverage(r1, r2); Codecov.submit_token(r)'
+# Analyze and submit results
+./julia -e 'using Coverage, HDF5, JLD; results=Codecov.process_folder("base"); Codecov.submit_token(results)'

--- a/src/CoverageBase.jl
+++ b/src/CoverageBase.jl
@@ -1,6 +1,6 @@
 module CoverageBase
 using Coverage
-export testnames, runtests, merge_coverage
+export testnames, runtests
 
 const need_inlining = ["reflection", "meta"]
 
@@ -41,41 +41,6 @@ function runtests(names)
             include(tst*".jl")
         end
     end
-end
-
-function merge_coverage_counts(a1, a2)
-    n = max(length(a1),length(a2))
-    a = Array(Union(Void,Int), n)
-    for i = 1:n
-        a1v = isdefined(a1, i) ? a1[i] : nothing
-        a2v = isdefined(a2, i) ? a2[i] : nothing
-        a[i] = a1v == nothing ? a2v :
-               a2v == nothing ? a1v : max(a1v, a2v)
-    end
-    a
-end
-
-function merge_coverage(r1a, r2a)
-    r1 = todict(r1a)
-    r2 = todict(r2a)
-    files = union(collect(keys(r1)), collect(keys(r2)))
-    r = FileCoverage[]
-    for f in files
-        src = haskey(r1, f) ? r1[f][1] : r2[f][1]
-        c1 = haskey(r1, f) ? r1[f][2] : Union(Void,Int)[nothing]
-        c2 = haskey(r2, f) ? r2[f][2] : Union(Void,Int)[nothing]
-        ff = FileCoverage(f,src,Coverage.merge_coverage_counts(c1,c2))
-        push!(r,ff)
-    end
-    r
-end
-
-function todict(results)
-    d = Dict{Any,Any}()
-    for r in results
-        d[r.filename] = (r.source, r.coverage)
-    end
-    d
 end
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,19 +6,3 @@ using Base.Test
 @test !isempty(testnames())
 @test_throws ErrorException runtests(["junk"])
 runtests([joinpath(CoverageBase.julia_top(), "test", "goto")])
-
-r1 = FileCoverage[FileCoverage("a","blahblah",[1,nothing,1,nothing]),
-                  FileCoverage("b","blahblah",[nothing,5])]
-r2 = FileCoverage[FileCoverage("a","blahblah",[3,nothing,0,2])]
-
-r = merge_coverage(r1, r2)
-@test length(r) == 2
-for ri in r
-    if ri.filename == "a"
-        @test ri.coverage == [3,nothing,1,2]
-    elseif ri.filename == "b"
-        @test ri.coverage == [nothing,5]
-    else
-        error("test not recognized")
-    end
-end


### PR DESCRIPTION
Since all the `.cov` files will have different PIDs from the two runs, we don't need to save the data in `.jld` files any more.

Tried this out [here](https://codecov.io/github/kshyatt/julia?ref=master) and it seems to be working well.
