### PR TITLE
Remove need_inline tests and enable coverage run with inlining on

### DIFF
--- a/src/CoverageBase.jl
+++ b/src/CoverageBase.jl
@@ -2,7 +2,7 @@ module CoverageBase
 using Coverage
 export testnames, runtests
 
-const need_inlining = ["reflection", "meta"]
+const need_inlining = []
 
 function julia_top()
     dir = joinpath(JULIA_HOME, "..", "share", "julia")
@@ -24,10 +24,10 @@ const testdir = joinpath(topdir, "test")
 include(joinpath(testdir, "choosetests.jl"))
 
 function testnames()
-    Base.JLOptions().can_inline == 1 && return need_inlining
-
     names, _ = choosetests()
-    filter!(x -> !in(x, need_inlining), names)
+    if Base.JLOptions().can_inline == 0
+        filter!(x -> !in(x, need_inlining), names)
+    end
 
     # Manually add in `pkg`, which is disabled so that `make testall` passes on machines without internet access
     push!(names, "pkg")


### PR DESCRIPTION
Requires https://github.com/JuliaLang/julia/pull/18665

How is multiple julia versions handled here? Do we keep track of a list of tests that needs inlining on? For master we should do https://github.com/staticfloat/julia-buildbot/issues/55 and disable/fix those tests directly. We could probably fix any broken tests with inlining off on released versions too.

Fix #18 
