### PR TITLE
Update for breaking change to spawn

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.42.0
+Compat 0.56.0
 Coverage

--- a/src/CoverageBase.jl
+++ b/src/CoverageBase.jl
@@ -7,6 +7,12 @@ export testnames, runtests
 
 const need_inlining = []
 
+if VERSION >= v"0.7.0-DEV.4445"
+    _spawn(cmd) = run(pipeline(cmd, stdin=devnull), wait=false)
+else
+    _spawn(cmd) = spawn(cmd, devnull, stdout, stderr)
+end
+
 function julia_top()
     dir = joinpath(BINDIR, "..", "share", "julia")
     if isdir(joinpath(dir,"base")) && isdir(joinpath(dir,"test"))
@@ -65,10 +71,10 @@ function runtests(names)
     fail = false
     cd(testdir) do
         for tst in names
-            print_with_color(:bold, "RUNTEST: $tst\n")
+            printstyled("RUNTEST: $tst\n", bold=true)
             cmd = Cmd(`$julia -e $script -- $tst`, dir = testdir)
             try
-                success(spawn(cmd, DevNull, STDOUT, STDERR))
+                success(_spawn(cmd))
             catch err
                 bt = catch_backtrace()
                 println(STDERR)


### PR DESCRIPTION
The `spawn` method used here was removed without deprecation in 0.7 (https://github.com/JuliaLang/julia/pull/26130), so this works around that.

cc @staticfloat, this should fix the errors seen with the coverage buildbot.